### PR TITLE
Fix link for public-apis

### DIFF
--- a/repo-json/jdorfman-awesome-json-datasets.json
+++ b/repo-json/jdorfman-awesome-json-datasets.json
@@ -601,7 +601,7 @@
   },
   {
     "name": "Public APIs (JSON APIs for use in web dev, some of which require authentication)",
-    "url": "https://github.com/toddmotto/public-apis"
+    "url": "https://github.com/public-apis/public-apis"
   },
   {
     "name": "Public Datasets (Datasets beyond just JSON)",


### PR DESCRIPTION
I noticed that public-apis is already on the list but containing a dated URL. Let's fix that.